### PR TITLE
7.4.1

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -37,7 +37,7 @@
   "modePatterns": { "message": "Use Enabled Proxies By Patterns and Order" },
   "modeDisabled": { "message": "Turn Off (Use Firefox Settings)" },
   "forAll": { "message": "for all URLs" },
-
+  "noProxies": { "message": "You do not have any proxy settings."},
 
   
   

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -111,6 +111,7 @@
   "patternHelp": { "message": "Pattern Help" },
   "welcome": { "message": "Welcome" },
   "options": { "message": "Options" },
+  "optionsPage": { "message": "FoxyProxy Options" },
   "enterUrl": { "message": "Enter URL to test" },
   "enterUrlNote": { "message": "(paths and query parameters are ignored)" },
   "patternDetail": { "message": "Enter pattern details." },

--- a/src/about.html
+++ b/src/about.html
@@ -67,6 +67,7 @@
         <li>Escape button works to close the current FoxyProxy window and return to the previous (if there is a previous).</li>
         <li>Dialog box color changes for consistency</li>
         <li>Import optimizations and increase on import file size from 5 MB to 10 MB</li>
+        <li>Show help text if no proxy settings are defined; hide all proxy selectors too including 'turn off'.</li>
       </ul>
       
       <h4>Version 7.4</h4>

--- a/src/about.html
+++ b/src/about.html
@@ -53,7 +53,7 @@
       <p>Please <a href="https://www.paypal.me/ericjung2/5.99" target="_blank">donate</a> or <a href="https://getfoxyproxy.org/order/" target="_blank">buy dedicated VPN/Proxy Servers</a> in over 100 countries (including such remote places like <a href="https://wikipedia.org/wiki/Réunion" target="_blank">Reunion Island</a>).</p>
       <p><strong>Thank you for using FoxyProxy!</strong></p>
       <img src="/images/ericjung.png" alt=""><br>
-      <p>&mdash; <a href="mailto:eric.jung@getfoxyproxy.org">Eric H. Jung</a><br>Colorado, USA</p>
+      <p>&mdash; <a href="mailto:eric.jung@getfoxyproxy.org">Eric H. Jung</a><br>Denver, Colorado, USA</p>
 
       <h3>Release Notes for Recent Releases</h3>
       <h4>Version 7.4.1</h4>
@@ -66,6 +66,7 @@
           And have many other support chanels: email, ticket system, github, facebook, twitter, chat, etc.</li>
         <li>Escape button works to close the current FoxyProxy window and return to the previous (if there is a previous).</li>
         <li>Dialog box color changes for consistency</li>
+        <li>Import optimizations and increase on import file size from 5 MB to 10 MB</li>
       </ul>
       
       <h4>Version 7.4</h4>

--- a/src/about.html
+++ b/src/about.html
@@ -44,9 +44,8 @@
       <h3>Help</h3>
       <p>
         <a href="https://support.getfoxyproxy.org/" target="_blank"><i class="fa fa-question"></i>Open a Support Ticket </a><i>(no registration required)</i><br>
-        <a href="mailto:support@getfoxyproxy.org"><i class="fa fa-envelope-o"></i>Email Support</a><br>
-        <a href="https://forums.getfoxyproxy.org/" target="_blank"><i class="fa fa-users"></i>Community Support Forums</a><br>
-        <a href="/pattern-tester.html"><i class="fa fa-flask"></i>Pattern Test</a> &amp; <a href="/pattern-help.html"><i class="fa fa-question-circle"></i>Pattern Help</a> <i>(no internet connection required)</i><br>
+        <a href="mailto:support@getfoxyproxy.org"><i class="fa fa-envelope-o"></i>Email Support</a><br>           
+        <span class="notForBasic"><a href="/pattern-tester.html"><i class="fa fa-flask"></i>Pattern Test</a> &amp; <a href="/pattern-help.html"><i class="fa fa-question-circle"></i>Pattern Help</a> <i>(no internet connection required)</i><br></span>
         <a href="https://getfoxyproxy.org/geoip/" target="_blank"><i class="fa fa-globe"></i>What's my IP Address?</a>
       </p>
 
@@ -57,6 +56,18 @@
       <p>&mdash; <a href="mailto:eric.jung@getfoxyproxy.org">Eric H. Jung</a><br>Colorado, USA</p>
 
       <h3>Release Notes for Recent Releases</h3>
+      <h4>Version 7.4.1</h4>
+      <ul>
+        <li>Fixes so that FoxyProxy Basic can share the same codebase as FoxyProxy Standard again. Version number alignment: for the first time since FoxyProxy Basic
+          was introduced, it will share the same version number as FoxyProxy Standard.</li>
+        <li>Exported settings now include FoxyProxy edition &mdash; Standard or Basic. However, they are interchangeable.</li>
+        <li>Removed link to <a href="https://forums.getfoxyproxy.org/" target="_blank"><i class="fa fa-users"></i>Community Support Forums</a>.
+          We are shutting the forums down. People just don't use forums anymore; we only get spam there.
+          And have many other support chanels: email, ticket system, github, facebook, twitter, chat, etc.</li>
+        <li>Escape button works to close the current FoxyProxy window and return to the previous (if there is a previous).</li>
+        <li>Dialog box color changes for consistency</li>
+      </ul>
+      
       <h4>Version 7.4</h4>
       <ul>
         <li>Uses new proxy API now and works with Firefox Nighly; discussed <a target="_blank" href="https://github.com/foxyproxy/firefox-extension/issues/39">here</a>. Minimum Firefox version is now 60.0.</li>
@@ -93,12 +104,6 @@
         <li>Fix minor import bug when importing FoxyProxy settings for paid accounts.</li>
       </ul>
       
-      <h4>Version 7.1</h4>
-      <ul>
-        <li>Patterns bugfix for bug introduced in 7.0</li>
-        <li>Text changes in patterns window</li>
-      </ul>
-
     <div style="text-align: right;">
       <button type="button" class="button" data-i18n="back">&#x25c1; </button>
     </div>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "7.4",
+  "version": "7.4.1",
   "default_locale": "en",
   "homepage_url": "https://getfoxyproxy.org/",
   "author": "Eric Jung",

--- a/src/options.html
+++ b/src/options.html
@@ -48,7 +48,7 @@
   <body>
 
     <!-- header -->
-    <div class="prime header" data-i18n="options"></div>
+    <div class="prime header" data-i18n="optionsPage"></div>
 
 
     <!-- spinner -->
@@ -122,8 +122,8 @@
         <h3></h3>
         <div></div>
         <div style="text-align: right;">
-          <button type="button" class="flat" data-i18n="cancel"></button>&nbsp;
-          <button type="button" class="flat" data-i18n="ok"></button>
+          <button type="button" class="alert" data-i18n="cancel"></button>&nbsp;
+          <button type="submit" data-i18n="ok"></button>
         </div>
       </div>
     </div>

--- a/src/options.html
+++ b/src/options.html
@@ -73,10 +73,10 @@
           <a data-i18n="about"><i class="fa fa-info-circle"></i></a>
         </nav>
 
-        <div class="rightColumn">
+        <div id="rightColumn" class="rightColumn">
 
           <!-- select & sync -->
-          <div class="flex">
+          <div id="selectAndSync" class="flex">
             <select id="mode">
               <option value="patterns" style="color: #f90;" data-i18n="modePatterns"></option>
               <option value="disabled" style="color: red;" data-i18n="modeDisabled"></option>
@@ -91,7 +91,11 @@
 
           <!-- proxy list -->
           <div id="accounts" class="scroll"></div>
-
+          <div id="help" style="text-align: center;margin: 15% auto"> <!-- try to center -->
+            <span data-i18n="noProxies"></span>
+            Please click <a data-i18n="add" href="/proxy.html"><i class="fa fa-plus-circle"></i> </a> to start.
+          </div>
+          
           <!-- template -->
           <div class="pxy flex template">
             <div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -43,7 +43,7 @@
     <div class="prime" style="margin: 0;">
 
 
-        <ul class="scroll">
+        <ul id="scroll" class="scroll">
           <li id="patterns" data-i18n="modePatterns"></li>
           
           <!-- template -->

--- a/src/scripts/about.js
+++ b/src/scripts/about.js
@@ -8,11 +8,19 @@ document.querySelectorAll('[data-i18n]').forEach(node => {
 });
 // ----------------- /Internationalization -----------------
 
+document.addEventListener('keyup', evt => {
+  if (evt.keyCode === 27) {
+    location.href = '/options.html';
+  }
+});
+
 const manifest = chrome.runtime.getManifest();
 document.querySelector('#version').textContent = manifest.version;
-document.querySelector('#edition').textContent = chrome.i18n.getMessage('extensionName');
+document.querySelector('#edition').textContent = 'FoxyProxy ' + (FOXYPROXY_BASIC ? 'Basic' : 'Standard');
 document.querySelector('button').addEventListener('click', () => location.href = '/options.html');
 
+// --- remove nodes completely for FP Basic
+FOXYPROXY_BASIC && document.querySelectorAll('.notForBasic').forEach(item => item.remove());
 
 // --- welcome on install/update
 location.search === '?welcome' && document.querySelector('.welcome').classList.remove('hide');

--- a/src/scripts/import.js
+++ b/src/scripts/import.js
@@ -49,11 +49,11 @@ function process(e) {
 
     case 'importJson':
       showSpinner();
-      Utils.importFile(e.target.files[0], ['application/json'], 1024*1024*5, 'json', importJson); // 5mb
+      Utils.importFile(e.target.files[0], ['application/json'], 1024*1024*10, 'json', importJson); // 10mb
       break;
     case 'importXml':
       showSpinner();
-      Utils.importFile(e.target.files[0], ['text/xml'], 1024*1024*5, 'xml', importXml);  // 5mb
+      Utils.importFile(e.target.files[0], ['text/xml'], 1024*1024*10, 'xml', importXml);  // 10mb
       break;
   }
 }
@@ -74,6 +74,12 @@ function importJson(result) {
 }
 
 function save(result, callback) {
+
+  // Remove 'browserVersion', 'foxyProxyVersion', 'foxyProxyEdition' if they exist
+  // We don't need those imported.
+  delete result.browserVersion;
+  delete result.foxyProxyVersion;
+  delete result.foxyProxyEdition;
 
   const  storageArea = result.sync ? chrome.storage.sync : chrome.storage.local;
 

--- a/src/scripts/log.js
+++ b/src/scripts/log.js
@@ -8,6 +8,13 @@ document.querySelectorAll('[data-i18n]').forEach(node => {
 });
 // ----------------- /Internationalization -----------------
 
+document.addEventListener('keyup', evt => {
+  if (evt.keyCode === 27) {
+    // We either came from /options.html or were opened as a new tab from popup.html (in that case, do nothing)
+    history.back();
+  }
+});
+
 // ----------------- Spinner -------------------------------
 const spinner = document.querySelector('.spinner');
 function hideSpinner() {

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -292,7 +292,21 @@ function processOptions(pref) {
     });
   }));
 
+  doWeHaveProxiesDefined();
   hideSpinner();
+}
+
+function doWeHaveProxiesDefined() {
+  if (!accounts.hasChildNodes()) {
+    document.querySelector('#help').style.display = 'block';
+    document.querySelector('#rightColumn').classList.add('secondary');
+    document.querySelector('#selectAndSync').style.display = 'none';
+  }
+  else {
+    document.querySelector('#help').style.display = 'none';
+    document.querySelector('#rightColumn').classList.remove('warning');
+    document.querySelector('#selectAndSync').style.display = 'flex';
+  }
 }
 
 function getFlag(cc) {
@@ -329,7 +343,7 @@ function processButton() {
     case 'delete|title':
       if (confirm(chrome.i18n.getMessage('confirmDelete'))) {
         parent.style.opacity = 0;
-        setTimeout(() => { parent.remove(); }, 600);          // remove row
+        setTimeout(() => { parent.remove(); doWeHaveProxiesDefined();}, 600);          // remove row
         storageArea.remove(id);
       }
       break;

--- a/src/scripts/patterns.js
+++ b/src/scripts/patterns.js
@@ -8,6 +8,12 @@ document.querySelectorAll('[data-i18n]').forEach(node => {
 });
 // ----------------- /Internationalization -----------------
 
+document.addEventListener('keyup', evt => {
+  if (evt.keyCode === 27) {
+    history.back(); // We either came from /proxy.html or /options.html
+  }
+});
+
 // ----------------- Spinner -------------------------------
 const spinner = document.querySelector('.spinner');
 function hideSpinner() {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -30,11 +30,10 @@ function processOptions(pref) {
   prefKeys.sort((a, b) => pref[a].index - pref[b].index);   // sort by index
   
   pref.mode = pref.mode || 'disabled';                      // defaults to disabled
-  let foundPattern;
+  let foundPattern, hasProxySettings = false;
   prefKeys.forEach(id => {
 
     const item = pref[id];
-    
     // check item.whitePatterns exists, otherwise this page won't render at all.
     // some people import patterns json using the primary import button
     // and therefore dont have items.whitePatterns.
@@ -50,6 +49,7 @@ function processOptions(pref) {
       li.children[1].textContent = '(' + chrome.i18n.getMessage('forAll') + ')';
 
       docfrag.appendChild(li);
+      hasProxySettings = true;
     }
   });
 
@@ -60,6 +60,9 @@ function processOptions(pref) {
     pref.mode === 'patterns' && (pref.mode = 'disabled');
   } 
   
+  // hide the selections if there are no proxy settings defined
+  document.getElementById('scroll').style.display = hasProxySettings ? 'block' : 'none';
+    
   const node = document.getElementById(pref.mode);          // querySelector error with selectors starting with number
   node.classList.add('on');
   

--- a/src/scripts/proxy.js
+++ b/src/scripts/proxy.js
@@ -8,6 +8,12 @@ document.querySelectorAll('[data-i18n]').forEach(node => {
 });
 // ----------------- /Internationalization -----------------
 
+document.addEventListener('keyup', evt => {
+  if (evt.keyCode === 27) {
+    close();
+  }
+});
+  
 // ----- global
 let proxy = {}, proxiesAdded = 0;
 const color = new jscolor('colorChooser', {uppercase: false, hash: true});
@@ -72,8 +78,7 @@ function process() {
   switch (this.dataset.i18n) {
 
     case 'cancel':
-      proxyPassword.value = '';                             // prevent Firefox's save password prompt
-      location.href = '/options.html';
+      close();
       break;
 
     case 'saveAdd':
@@ -157,8 +162,13 @@ function makeProxy() {
     proxy.username = proxyUsername.value;                   // if it had u/p and then deletd it, it must be reflected
     proxy.password = proxyPassword.value;
   }
-  proxy.whitePatterns = proxy.whitePatterns || (document.querySelector('#whiteAll').checked ? [PATTERN_ALL_WHITE] : []);
-  proxy.blackPatterns = proxy.blackPatterns || (document.querySelector('#blackAll').checked ? blacklistSet : []);
+  if (FOXYPROXY_BASIC) {
+    proxy.whitePatterns = proxy.blackPatterns = [];
+  }
+  else {
+    proxy.whitePatterns = proxy.whitePatterns || (document.querySelector('#whiteAll').checked ? [PATTERN_ALL_WHITE] : []);
+    proxy.blackPatterns = proxy.blackPatterns || (document.querySelector('#blackAll').checked ? blacklistSet : []);
+  }
   proxy.pacURL = proxy.pacURL || pacURL.value;  // imported foxyproxy.xml
 
   if (!id) {  // global
@@ -181,7 +191,7 @@ function validateInput() {
 
   document.querySelectorAll('input[type="text"]').forEach(item => item.value = item.value.trim());
 
-  // let's handle here, #proxyPort will be checks later separately
+  // let's handle here, #proxyPort will be checked later separately
   // Utils.escapeAllInputs('#proxyTitle,#proxyAddress,#proxyPort');
   // escape all inputs
   [proxyTitle, proxyAddress].forEach(item => item.value = item.value.replace(/[&<>"']+/g, ''));
@@ -217,4 +227,9 @@ function resetOptions() {
 
   setHeader();  
   proxyTitle.focus();
-} 
+}
+
+function close() {
+  proxyPassword.value = ''; /* prevent Firefox's save password prompt */
+  location.href = '/options.html';
+}

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -25,7 +25,7 @@ const PATTERN_TYPE_WILDCARD = 1;
 const PATTERN_TYPE_REGEXP = 2;
 
 // Storage keys that are not proxy settings
-const NON_PROXY_KEYS = ['mode', 'logging', 'sync', 'browserVersion', 'foxyProxyVersion', 'nextIndex'];
+const NON_PROXY_KEYS = ['mode', 'logging', 'sync', 'browserVersion', 'foxyProxyVersion', 'foxyProxyEdition', 'nextIndex'];
 
 // bg | import | proxy | utils
 const PATTERN_ALL_WHITE = {

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -218,6 +218,7 @@ class Utils {
     // Browser version and extension version. These are used for debugging.
     settings.browserVersion = browserVersion;
     settings.foxyProxyVersion = chrome.runtime.getManifest().version;
+    settings.foxyProxyEdition = FOXYPROXY_BASIC ? 'basic' : 'standard';
     settings.sync = sync;
     const blob = new Blob([JSON.stringify(settings, null, 2)], {type : 'text/plain;charset=utf-8'});
     const filename = chrome.i18n.getMessage('extensionName') + '_' + new Date().toISOString().substring(0, 10) + '.json';

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -473,7 +473,7 @@ input.switch:checked + label::after {
 
 .popup h3 {
   color: #fff;
-  background-color: #f80;
+  background-color: #630;
   margin: 0 0 1em;
   padding: 0.5em;
   border-radius: 10px 10px 0 0 ;
@@ -498,11 +498,6 @@ input.switch:checked + label::after {
   margin: 0;
 }
 
-.popup button:first-of-type {
-  background: none;
-  border: none;
-  color: #f90;
-}
 /* ----- /Popup ----- */
 
 


### PR DESCRIPTION
* Escape button works to close the current FoxyProxy window and return to the previous (if there is a previous).
* Dialog box color changes for consistency
* Import optimizations and increase on import file size from 5 MB to 10 MB
* Show help text if no proxy settings are defined; hide all proxy selectors too including 'turn off'.
* Fixes so that FoxyProxy Basic can share the same codebase as FoxyProxy Standard again. Version number alignment: for the first time since FoxyProxy Basic
  was introduced, it will share the same version number as FoxyProxy Standard.
* Exported settings now include FoxyProxy edition -- Standard or Basic. However, they are interchangeable. This is for easier debugging of problems.
* Removed link to forums.getfoxyproxy.org. We are shutting the forums down. People just don't use forums anymore; we only get spam there. And have many other support channels: email, ticket system, github, facebook, twitter, chat, etc.
