### PR TITLE
7.4.2

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -150,5 +150,9 @@
   "proxyTitle": { "message": "Proxy Title" },
   "proxyAddress": { "message": "Proxy Address" },
   "matchPattern": { "message": "Match Pattern" },
-  "timestamp": { "message": "Timestamp" }
+  "whiteBlack": { "message": "White/Black" },
+  "white": { "message": "White" },
+  "black": { "message": "Black" },
+  "timestamp": { "message": "Timestamp" },
+  "notApplicable": {"message": "n/a"}
 } 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -73,7 +73,7 @@
 
   "disabled": { "message": "Disabled" },
   "active": { "message": "Enabled" },
-	"activeNote.1": { "message": "FoxyProxy ignores everything on this page unless set to" },
+	"activeNote": { "message": "FoxyProxy ignores everything on this page unless set to" },
   "noMatch": { "message": "No Match" },
   "none": { "message": "None" },
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -154,5 +154,7 @@
   "white": { "message": "White" },
   "black": { "message": "Black" },
   "timestamp": { "message": "Timestamp" },
-  "notApplicable": {"message": "n/a"}
+  "notApplicable": {"message": "n/a"},
+  "matchedURLs": {"message": "URLs That Matched Patterns"},
+  "unmatchedURLs": {"message": "URLs That Did Not Match Patterns"}
 } 

--- a/src/about.html
+++ b/src/about.html
@@ -56,6 +56,15 @@
       <p>&mdash; <a href="mailto:eric.jung@getfoxyproxy.org">Eric H. Jung</a><br>Denver, Colorado, USA</p>
 
       <h3>Release Notes for Recent Releases</h3>
+      <h4>Version 7.4.2</h4>
+      <ul>
+        <li>When adding a new proxy, <strong>Add whitelist pattern to match all URLs</strong> is now on by default. Discussed <a href="https://github.com/foxyproxy/firefox-extension/issues/49" target="_blank">here</a>.</li>
+        <li>On patterns window, added button for <strong>Add whitelist pattern to match all URLs</strong> similar to the existing button <strong>Add black patterns to prevent this proxy being used for localhost & intranet/private IP addresses</strong>.</li>
+        <li>Patterns Cheat Sheet improvements &mdash; more examples and text explaining that blacklist patterns take precedence over whitelist patterns.</li>
+        <li>Change an i18n key name so it works in chrome, too (chrome does not allow periods in key names).</li>
+        <li>Remove unneeded console log messages.</li>
+        <li>Faster deletion of patterns (faster animation)</li>
+      </ul>
       <h4>Version 7.4.1</h4>
       <ul>
         <li>Fixes so that FoxyProxy Basic can share the same codebase as FoxyProxy Standard again. Version number alignment: for the first time since FoxyProxy Basic
@@ -69,43 +78,6 @@
         <li>Import optimizations and increase on import file size from 5 MB to 10 MB</li>
         <li>Show help text if no proxy settings are defined; hide all proxy selectors too including 'turn off'.</li>
       </ul>
-      
-      <h4>Version 7.4</h4>
-      <ul>
-        <li>Uses new proxy API now and works with Firefox Nighly; discussed <a target="_blank" href="https://github.com/foxyproxy/firefox-extension/issues/39">here</a>. Minimum Firefox version is now 60.0.</li>
-        <li>Toolbar icon now changes with proxy use, just like version 6.x and earlier (patterns mode only). If there are no matches, a gray icon is displayed; discussed <a target="_blank" href="https://github.com/foxyproxy/firefox-extension/issues/38">here</a>.</li>
-        <li>Logging improvements; log now displays unmatched URLs just like version 6.x and earlier. This makes it obvious which URLs you may want to write patterns for.</li>
-        <li>UI Improvements</li>
-        <li>Performance improvements for authentication</li>
-        <li>Add browser and extension version numbers to export for debugging of exported settings submitted by users. It will be useful also in the future as the fileformat matures and changes, as it has many times over the years.</li>
-        <li>Ensure new proxies are added to the top of the list when created</li>
-        <li>Remove migration code which seems to cause errors for some people; migration from very old versions now gone.</li>
-        <li>Do not display pattern shortcuts (match all URLs, don't match localhost & intranet IPs) when editing a proxy setting, just like 6.x and earlier. Showing these created a lot of confusion for some users. Sorry!</li>
-        <li>
-        
-        <div class="tooltip"><span class="orangehover">Pattern Cheat Sheet</span> <i class="fa fa-info-circle"></i>
-          <span class="tooltiptext center">
-            <span class="monospace">bbc.co.uk</span> &mdash; exact domain only<br>
-            <span class="monospace">*.bbc.co.uk</span> &mdash; exact domain and all subdomains<br>
-            <span class="monospace">**.bbc.co.uk</span> &mdash; subdomains only, not bbc.co.uk
-          </span>
-         on pattern-related pages</div>
-      </li>
-      <li>Bug fixes when importing legacy foxyproxy.xml settings (FoxyProxy 4.x and earlier)</li>
-      <li>Show patterns buttons when adding Direct (no proxy) setting. Fixed some minor UI bugs when using Direct (no proxy).</li>
-      </ul>      
-      <h4>Version 7.3</h4>
-      <ul>
-        <li><a href="https://github.com/foxyproxy/firefox-extension/issues/33">Another</a> pattern bugfix.</li>
-        <li>Fix for inability to turn off <i>Send DNS through SOCKS5 proxy</i>; discussed <a href="https://github.com/foxyproxy/firefox-extension/issues/35">here</a>.</li>
-      </ul>
-      
-      <h4>Version 7.2</h4>
-      <ul>
-        <li>HTTP Basic Auth bugfix introduced in 7.0; discussed <a href="https://github.com/foxyproxy/firefox-extension/issues/30">here</a>.</li>
-        <li>Fix minor import bug when importing FoxyProxy settings for paid accounts.</li>
-      </ul>
-      
     <div style="text-align: right;">
       <button type="button" class="button" data-i18n="back">&#x25c1; </button>
     </div>

--- a/src/about.html
+++ b/src/about.html
@@ -58,8 +58,12 @@
       <h3>Release Notes for Recent Releases</h3>
       <h4>Version 7.4.2</h4>
       <ul>
+        <li>Improved Logging &mdash; see URLs that matched blacklist patterns and URLs that didn't match anything are now in their own section.</li>
+        <li>Patterns mode now exists even if there are no white patterns defined. This was the behavior of FoxyProxy before 7.x. Its absence when no white patterns
+          are defined makes sense (no proxy will ever be used), but has been a source of tremendous confusion. Discussed <a href="https://github.com/foxyproxy/firefox-extension/issues/49" target="_blank">here</a>
+        but also many other places.</li>
         <li>When adding a new proxy, <strong>Add whitelist pattern to match all URLs</strong> is now on by default. Discussed <a href="https://github.com/foxyproxy/firefox-extension/issues/49" target="_blank">here</a>.</li>
-        <li>On patterns window, added button for <strong>Add whitelist pattern to match all URLs</strong> similar to the existing button <strong>Add black patterns to prevent this proxy being used for localhost & intranet/private IP addresses</strong>.</li>
+        <li>On the patterns window, added new button for <strong>Add whitelist pattern to match all URLs</strong> similar to the existing button <strong>Add black patterns to prevent this proxy being used for localhost & intranet/private IP addresses</strong>.</li>
         <li>Patterns Cheat Sheet improvements &mdash; more examples and text explaining that blacklist patterns take precedence over whitelist patterns.</li>
         <li>Change an i18n key name so it works in chrome, too (chrome does not allow periods in key names).</li>
         <li>Remove unneeded console log messages.</li>

--- a/src/log.html
+++ b/src/log.html
@@ -75,11 +75,13 @@
           <thead>
             <tr>
               <th data-i18n="url"></th><th data-i18n="proxyTitle"></th><th data-i18n="color"></th>
-              <th data-i18n="proxyAddress"></th><th data-i18n="matchPattern"></th><th data-i18n="timestamp"></th>
+              <th data-i18n="proxyAddress"></th><th data-i18n="matchPattern"></th><th data-i18n="whiteBlack"></th>
+              <th data-i18n="timestamp"></th>
              </tr>
             <!-- template -->
             <tr class="template">
                <td><a href="" target="_blank"></a></td>
+               <td></td>
                <td></td>
                <td></td>
                <td></td>

--- a/src/log.html
+++ b/src/log.html
@@ -70,6 +70,7 @@
         A row in this log does not mean the URL successfully loaded. The log shows only how <strong>attempts</strong> were made to load URLs. If the proxy server was not responding or there was some other problem which prevented the URL from loading, the URL still displays here. This is a limitation of Firefox 57+.
       </div>
 
+      <h3 data-i18n="matchedURLs"></h3>
       <div class="scroll">
         <table>
           <thead>
@@ -79,7 +80,7 @@
               <th data-i18n="timestamp"></th>
              </tr>
             <!-- template -->
-            <tr class="template">
+            <tr class="matchedtemplate">
                <td><a href="" target="_blank"></a></td>
                <td></td>
                <td></td>
@@ -94,6 +95,25 @@
         </table>
       </div>
 
+      <h3 data-i18n="unmatchedURLs"></h3>
+      <div class="scroll">
+        <table>
+          <thead>
+            <tr>
+              <th data-i18n="url"></th>
+              <th data-i18n="timestamp"></th>
+             </tr>
+            <!-- template -->
+            <tr class="unmatchedtemplate">
+               <td><a href="" target="_blank"></a></td>
+               <td></td>
+            </tr>
+          </thead>
+
+          <tbody></tbody>
+        </table>
+      </div>
+      
       <div style="margin-top: 1em; text-align: right;">
         <button type="button" data-i18n="back">&#x25c1; </button>
         <button type="button" data-i18n="refresh"><i class="fa fa-refresh"></i> </button>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "default_locale": "en",
   "homepage_url": "https://getfoxyproxy.org/",
   "author": "Eric Jung",

--- a/src/pattern-help.html
+++ b/src/pattern-help.html
@@ -21,13 +21,25 @@
 
       <div style="text-align: right;">
         
-        <div class="tooltip"><span data-i18n="patternCheatSheet" class="orangehover"></span> <i class="fa fa-info-circle"></i>
-          <span class="tooltiptext center bottom">
-            <span class="monospace">*</span> &mdash; all domains<br>
-            <span class="monospace">bbc.co.uk</span> &mdash; exact domain only<br>
-            <span class="monospace">*.bbc.co.uk</span> &mdash; exact domain and all subdomains<br>
-            <span class="monospace">**.bbc.co.uk</span> &mdash; subdomains only, not bbc.co.uk
-          </span>
+        <div class="tooltip">
+          <span data-i18n="patternCheatSheet" class="fp-orange"></span>
+          <i class="fa fa-info-circle"></i>
+          <div class="tooltiptext bottom table">
+            <div class="tooltiptable">
+              <div class="monospace">*</div>
+              <div>all domains</div>
+              <div class="monospace">*.bbc.co.uk</div>
+              <div>exact domain and all subdomains</div>
+              <div class="monospace">**.bbc.co.uk</div>
+              <div>subdomains only (not bbc.co.uk)</div>
+              <div class="monospace">bbc.co.uk</div>
+              <div>exact domain only</div>
+            </div>
+            <hr>
+            <div class="tooltiptablefooter">
+              <div>Black patterns take precedence over white patterns. For example, a black pattern of <span class="monospace">*</span> means nothing will match, regardless of any white patterns.</div>
+            </div>
+          </div>
         </div>
         |
         <a href="/pattern-tester.html" target="_blank"><span data-i18n="patternTester"></span> <i class="fa fa-flask"></i></a>

--- a/src/pattern-help.html
+++ b/src/pattern-help.html
@@ -22,7 +22,8 @@
       <div style="text-align: right;">
         
         <div class="tooltip"><span data-i18n="patternCheatSheet" class="orangehover"></span> <i class="fa fa-info-circle"></i>
-          <span class="tooltiptext center">
+          <span class="tooltiptext center bottom">
+            <span class="monospace">*</span> &mdash; all domains<br>
             <span class="monospace">bbc.co.uk</span> &mdash; exact domain only<br>
             <span class="monospace">*.bbc.co.uk</span> &mdash; exact domain and all subdomains<br>
             <span class="monospace">**.bbc.co.uk</span> &mdash; subdomains only, not bbc.co.uk

--- a/src/pattern-tester.html
+++ b/src/pattern-tester.html
@@ -25,7 +25,8 @@
       <div style="text-align: right;">
         
         <div class="tooltip"><span data-i18n="patternCheatSheet" class="orangehover"></span> <i class="fa fa-info-circle"></i>
-          <span class="tooltiptext center">
+          <span class="tooltiptext center bottom">
+            <span class="monospace">*</span> &mdash; all domains<br>
             <span class="monospace">bbc.co.uk</span> &mdash; exact domain only<br>
             <span class="monospace">*.bbc.co.uk</span> &mdash; exact domain and all subdomains<br>
             <span class="monospace">**.bbc.co.uk</span> &mdash; subdomains only, not bbc.co.uk

--- a/src/pattern-tester.html
+++ b/src/pattern-tester.html
@@ -24,13 +24,25 @@
 
       <div style="text-align: right;">
         
-        <div class="tooltip"><span data-i18n="patternCheatSheet" class="orangehover"></span> <i class="fa fa-info-circle"></i>
-          <span class="tooltiptext center bottom">
-            <span class="monospace">*</span> &mdash; all domains<br>
-            <span class="monospace">bbc.co.uk</span> &mdash; exact domain only<br>
-            <span class="monospace">*.bbc.co.uk</span> &mdash; exact domain and all subdomains<br>
-            <span class="monospace">**.bbc.co.uk</span> &mdash; subdomains only, not bbc.co.uk
-          </span>
+        <div class="tooltip">
+          <span data-i18n="patternCheatSheet" class="fp-orange"></span>
+          <i class="fa fa-info-circle"></i>
+          <div class="tooltiptext bottom table">
+            <div class="tooltiptable">
+              <div class="monospace">*</div>
+              <div>all domains</div>
+              <div class="monospace">*.bbc.co.uk</div>
+              <div>exact domain and all subdomains</div>
+              <div class="monospace">**.bbc.co.uk</div>
+              <div>subdomains only (not bbc.co.uk)</div>
+              <div class="monospace">bbc.co.uk</div>
+              <div>exact domain only</div>
+            </div>
+            <hr>
+            <div class="tooltiptablefooter">
+              <div>Black patterns take precedence over white patterns. For example, a black pattern of <span class="monospace">*</span> means nothing will match, regardless of any white patterns.</div>
+            </div>
+          </div>
         </div>
         |
         <a href="/pattern-help.html" target="_blank"><span data-i18n="patternHelp"></span> <i class="fa fa-question-circle"></i></a>

--- a/src/patterns.html
+++ b/src/patterns.html
@@ -61,7 +61,7 @@
         
         <div class="flex">
           <div class="prime warning small" style="flex: 1.5">
-              <span data-i18n="activeNote.1"></span> <strong><span data-i18n="modePatterns"></span></strong>
+              <span data-i18n="activeNote"></span> <strong><span data-i18n="modePatterns"></span></strong>
     			</div>
           <div style="text-align: right;">
             <div class="tooltip"><span data-i18n="patternCheatSheet" class="orangehover"></span> <i class="fa fa-info-circle"></i>

--- a/src/patterns.html
+++ b/src/patterns.html
@@ -65,10 +65,12 @@
     			</div>
           <div style="text-align: right;">
             <div class="tooltip"><span data-i18n="patternCheatSheet" class="orangehover"></span> <i class="fa fa-info-circle"></i>
-              <span class="tooltiptext center">
-                <span class="monospace">bbc.co.uk</span> &mdash; exact domain only<br>
-                <span class="monospace">*.bbc.co.uk</span> &mdash; exact domain and all subdomains<br>
-                <span class="monospace">**.bbc.co.uk</span> &mdash; subdomains only, not bbc.co.uk
+              <span class="tooltiptext bottom monospace" style="text-align: left; padding-left: 1rem">
+                <p><span>*</span> &mdash; all domains<br>
+                <span>bbc.co.uk</span> &mdash; exact domain only<br>
+                <span>*.bbc.co.uk</span> &mdash; exact domain and all subdomains<br>
+                <span>**.bbc.co.uk</span> &mdash; subdomains only, not bbc.co.uk</p>
+                <p><span>Black patterns take precedence over white patterns. For example, a black pattern of * means nothing will match, regardless of any white patterns.</span></p>
               </span>
             </div>
             |
@@ -125,6 +127,11 @@
         </table>
       </div>
 
+      <div style="margin: 1em 0 2em; text-align: center; font-size: 0.9em;">
+        <span data-i18n="addWhitelist"></span>
+        <div class="tooltip"><i class="fa fa-info-circle"></i><span class="tooltiptext center" data-i18n="addWhitelistTip"></span></div>
+        <button type="button" class="small" style="margin-left: 1em; vertical-align: initial;" data-i18n="add" data-white></button>
+      </div>
 
       <h3 data-i18n="blackPatterns"></h3>
       <div class="scroll">
@@ -145,7 +152,7 @@
       <div style="margin: 1em 0 2em; text-align: center; font-size: 0.9em;">
         <span data-i18n="addBlacklist"></span>
         <div class="tooltip"><i class="fa fa-info-circle"></i><span class="tooltiptext center" data-i18n="addBlacklistTip"></span></div>
-        <button type="button" class="small" style="margin-left: 1em; vertical-align: initial;" data-i18n="add"></button>
+        <button type="button" class="small" style="margin-left: 1em; vertical-align: initial;" data-i18n="add" data-black></button>
       </div>
 
       <div class="flex">

--- a/src/patterns.html
+++ b/src/patterns.html
@@ -40,6 +40,16 @@
       #result { margin: 1em 0 0; }
       label[for="file"] { margin: 0; }
       #links { float: right; }
+      hr { color: white; }
+      .addbuttoncontainer {
+        margin: 1em 0 2em;
+        text-align: center;
+        font-size: 0.9em;
+      }
+      .addbutton {
+        margin-left: 1em;
+        vertical-align: initial;
+      }
     </style>
   </head>
   <body>
@@ -64,14 +74,25 @@
               <span data-i18n="activeNote"></span> <strong><span data-i18n="modePatterns"></span></strong>
     			</div>
           <div style="text-align: right;">
-            <div class="tooltip"><span data-i18n="patternCheatSheet" class="orangehover"></span> <i class="fa fa-info-circle"></i>
-              <span class="tooltiptext bottom monospace" style="text-align: left; padding-left: 1rem">
-                <p><span>*</span> &mdash; all domains<br>
-                <span>bbc.co.uk</span> &mdash; exact domain only<br>
-                <span>*.bbc.co.uk</span> &mdash; exact domain and all subdomains<br>
-                <span>**.bbc.co.uk</span> &mdash; subdomains only, not bbc.co.uk</p>
-                <p><span>Black patterns take precedence over white patterns. For example, a black pattern of * means nothing will match, regardless of any white patterns.</span></p>
-              </span>
+            <div class="tooltip">
+              <span data-i18n="patternCheatSheet" class="fp-orange"></span>
+              <i class="fa fa-info-circle"></i>
+              <div class="tooltiptext bottom table">
+                <div class="tooltiptable">
+                  <div class="monospace">*</div>
+                  <div>all domains</div>
+                  <div class="monospace">*.bbc.co.uk</div>
+                  <div>exact domain and all subdomains</div>
+                  <div class="monospace">**.bbc.co.uk</div>
+                  <div>subdomains only (not bbc.co.uk)</div>
+                  <div class="monospace">bbc.co.uk</div>
+                  <div>exact domain only</div>
+                </div>
+                <hr>
+                <div class="tooltiptablefooter">
+                  <div>Black patterns take precedence over white patterns. For example, a black pattern of <span class="monospace">*</span> means nothing will match, regardless of any white patterns.</div>
+                </div>
+              </div>
             </div>
             |
             <a href="/pattern-tester.html" target="_blank"><span data-i18n="patternTester"></span> <i class="fa fa-flask"></i></a>
@@ -127,10 +148,10 @@
         </table>
       </div>
 
-      <div style="margin: 1em 0 2em; text-align: center; font-size: 0.9em;">
+      <div class="addbuttoncontainer">
         <span data-i18n="addWhitelist"></span>
         <div class="tooltip"><i class="fa fa-info-circle"></i><span class="tooltiptext center" data-i18n="addWhitelistTip"></span></div>
-        <button type="button" class="small" style="margin-left: 1em; vertical-align: initial;" data-i18n="add" data-white></button>
+        <button type="button" class="small addbutton" data-i18n="add" data-white></button>
       </div>
 
       <h3 data-i18n="blackPatterns"></h3>
@@ -149,10 +170,10 @@
       </div>
 
 
-      <div style="margin: 1em 0 2em; text-align: center; font-size: 0.9em;">
+      <div class="addbuttoncontainer">
         <span data-i18n="addBlacklist"></span>
         <div class="tooltip"><i class="fa fa-info-circle"></i><span class="tooltiptext center" data-i18n="addBlacklistTip"></span></div>
-        <button type="button" class="small" style="margin-left: 1em; vertical-align: initial;" data-i18n="add" data-black></button>
+        <button type="button" class="small addbutton" data-i18n="add" data-black></button>
       </div>
 
       <div class="flex">

--- a/src/proxy.html
+++ b/src/proxy.html
@@ -115,7 +115,7 @@
                 <label><span data-i18n="addWhitelist"></span>
                 <div class="tooltip"><i class="fa fa-info-circle"></i><span class="tooltiptext" data-i18n="addWhitelistTip"></span></div></label>
                 <div>
-                  <input type="checkbox" class="switch" id="whiteAll"><label for="whiteAll"></label>
+                  <input type="checkbox" class="switch" id="whiteAll" checked><label for="whiteAll"></label>
                 </div>
               </div>
       

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -213,7 +213,6 @@ let authData = {};
 let authPending = {};
 
 async function sendAuth(request) {
-  console.log("sendAuth()");
   // Do nothing if this not proxy auth request:
   // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired
   //   "Take no action: the listener can do nothing, just observing the request. If this happens, it will
@@ -245,7 +244,6 @@ async function getAuth(request) {
     chrome.storage.local.get(null, result => {
       const host = result.hostData[request.challenger.host];
       if (host && host.username) {                          // cache credentials in authData
-        console.log("here2");
         authData[host] = {username: host.username, password: host.password};
       }
       resolve();

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -15,21 +15,32 @@ class Logger {
 
   constructor(size = 100, active = false) {
     this.size = size;
-    this.list = [];
+    this.matchedList = [];
+    this.unmatchedList = [];
     this.active = active;
   }
 
   clear() {
-    this.list = [];
+    this.matchedList = [];
+    this.unmatchedList = [];
   }
 
-  add(item) {
-    this.list.push(item);                             // addds to the end
-    this.list = this.list.slice(-this.size);          // slice to the ending size entries
+  add(item, list) {
+    list.push(item);                        // adds to the end
+    list = list.slice(-this.size);          // slice to the ending size entries
+  }
+  
+  addMatched(item) {
+    this.add(item, this.matchedList);
+  }
+
+  addUnmatched(item) {
+    this.add(item, this.unmatchedList);
   }
 
   updateStorage() {
-    this.list = this.list.slice(-this.size);          // slice to the ending size entries
+    this.matchedList = this.matchedList.slice(-this.size);          // slice to the ending size entries
+    this.unmatchedList = this.unmatchedList.slice(-this.size);      // slice to the ending size entries
     storageArea.set({logging: {size: this.size, active: this.active} });
   }
 }

--- a/src/scripts/log.js
+++ b/src/scripts/log.js
@@ -82,14 +82,15 @@ function renderLog() {
   const tbody = tr.parentNode.nextElementSibling;
   tbody.textContent = ''; // clearing the content
 
-  const forAll = chrome.i18n.getMessage('forAll');;
-
+  const forAll = chrome.i18n.getMessage('forAll');
+  const NA = chrome.i18n.getMessage('notApplicable');
+  
   logger.list.forEach(item => {
 
     const pattern = item.matchedPattern ?
       (item.matchedPattern === 'all' ? forAll : item.matchedPattern) : 'No matches';
 
-    // Build a row for this log entry by cloning the tr containing 6 td
+    // Build a row for this log entry by cloning the tr containing 7 td
     const row = tr.cloneNode(true);
     row.className = item.matchedPattern ? 'success' : 'secondary'; // this will rest class .tamplate as well
     const td = row.children;
@@ -98,11 +99,12 @@ function renderLog() {
     a.href = item.url;
     a.textContent = item.url;
 
-    td[1].textContent = item.title || 'n/a';
+    td[1].textContent = item.title || NA;
     td[2].style.backgroundColor = item.color || 'blue';
-    td[3].textContent = item.address || 'n/a';
+    td[3].textContent = item.address || NA;
     td[4].textContent = pattern;
-    td[5].textContent = formatInt(item.timestamp);
+    td[5].textContent = item.whiteBlack || NA;
+    td[6].textContent = formatInt(item.timestamp);
 
     docfrag.appendChild(row);
   });

--- a/src/scripts/log.js
+++ b/src/scripts/log.js
@@ -40,7 +40,8 @@ chrome.runtime.getBackgroundPage(bg => {
   logger = bg.getLog();
   onOff.checked = logger.active;
   logSize.value = logger.size;
-  renderLog(); // log content will be shown if there are any, regardless of onOff
+  renderMatchedLog(); // log content will be shown if there are any, regardless of onOff
+  renderUnmatchedLog();  // log content will be shown if there are any, regardless of onOff
   hideSpinner();
 });
 
@@ -66,26 +67,30 @@ function process () {
   switch (this.dataset.i18n) {
 
     case 'back': location.href = '/options.html'; break;
-    case 'refresh': renderLog(); break;
+    case 'refresh':
+      renderMatchedLog();
+      renderUnmatchedLog();
+      break;
     case 'clear':
       logger.clear();
-      renderLog();
+      renderMatchedLog();
+      renderUnmatchedLog();
       break;
   }
 }
 
-function renderLog() {
+function renderMatchedLog() {
 
   // ----- templates & containers
   const docfrag = document.createDocumentFragment();
-  const tr = document.querySelector('tr.template');
+  const tr = document.querySelector('tr.matchedtemplate');
   const tbody = tr.parentNode.nextElementSibling;
   tbody.textContent = ''; // clearing the content
 
   const forAll = chrome.i18n.getMessage('forAll');
   const NA = chrome.i18n.getMessage('notApplicable');
   
-  logger.list.forEach(item => {
+  logger.matchedList.forEach(item => {
 
     const pattern = item.matchedPattern ?
       (item.matchedPattern === 'all' ? forAll : item.matchedPattern) : 'No matches';
@@ -105,6 +110,30 @@ function renderLog() {
     td[4].textContent = pattern;
     td[5].textContent = item.whiteBlack || NA;
     td[6].textContent = formatInt(item.timestamp);
+
+    docfrag.appendChild(row);
+  });
+
+  tbody.appendChild(docfrag);
+}
+
+function renderUnmatchedLog() {
+
+  // ----- templates & containers
+  const docfrag = document.createDocumentFragment();
+  const tr = document.querySelector('tr.unmatchedtemplate');
+  const tbody = tr.parentNode.nextElementSibling;
+  tbody.textContent = ''; // clearing the content
+  
+  logger.unmatchedList.forEach(item => {
+    // Build a row for this log entry by cloning the tr containing 2 td
+    const row = tr.cloneNode(true);
+    const td = row.children;
+    const a = td[0].children[0];
+    
+    a.href = item.url;
+    a.textContent = item.url;
+    td[1].textContent = formatInt(item.timestamp);
 
     docfrag.appendChild(row);
   });

--- a/src/scripts/matcher.js
+++ b/src/scripts/matcher.js
@@ -35,7 +35,7 @@ function findProxyMatch(url, activeSettings) {
           item.pattern.test(hostPort));
 
       if (blackMatch) {
-        sendToLog(url, proxy, Utils.getProxyTitle(proxy), blackMatch, BLACK);
+        sendToMatchedLog(url, proxy, Utils.getProxyTitle(proxy), blackMatch, BLACK);
         continue; // if blacklist matched, continue to the next proxy
       }
 
@@ -47,13 +47,12 @@ function findProxyMatch(url, activeSettings) {
   			// found a whitelist match, end here
         const title = Utils.getProxyTitle(proxy);
         Utils.updateIcon('images/icon.svg', proxy.color, title, false, title, false);
-        // TODO: use a Promise for sendToLogAndHandleToolbarIcon()
-        sendToLog(url, proxy, title, whiteMatch, WHITE);
+        sendToMatchedLog(url, proxy, title, whiteMatch, WHITE);
         return prepareSetting(proxy);
   		}
     }
     // no white matches in any settings
-    sendToLog(url, {color: NOMATCH_COLOR, address: ''}, NOMATCH_TEXT, {originalPattern: NOMATCH_TEXT});
+    sendToUnmatchedLog(url);
     Utils.updateIcon('images/gray.svg', null, NOMATCH_TEXT, false, NOMATCH_TEXT, false);
     return {type: 'direct'};
   }
@@ -68,7 +67,7 @@ function findProxyMatch(url, activeSettings) {
     const p = activeSettings.proxySettings[0];
     const title = Utils.getProxyTitle(p);
     Utils.updateIcon('images/icon.svg', p.color, title, false, title, false);
-    sendToLog(url, p, title, FOR_ALL);
+    sendToMatchedLog(url, p, title, FOR_ALL);
     return prepareSetting(p);
   }
 }
@@ -98,9 +97,9 @@ function prepareSetting(proxy) {
   return ret;
 }
 
-function sendToLog(url, proxy, title, matchedPattern, whiteBlack) {
+function sendToMatchedLog(url, proxy, title, matchedPattern, whiteBlack) {
   // log only the data that is needed for display
-  logger && logger.active && logger.add({
+  logger && logger.active && logger.addMatched({
     url,
     title,
     color: proxy.color,
@@ -110,4 +109,8 @@ function sendToLog(url, proxy, title, matchedPattern, whiteBlack) {
     whiteBlack,
     timestamp: Date.now()
   });
+}
+
+function sendToUnmatchedLog(url) {
+  logger && logger.active && logger.addUnmatched({url, timestamp: Date.now()});
 }

--- a/src/scripts/matcher.js
+++ b/src/scripts/matcher.js
@@ -10,6 +10,8 @@ const FOR_ALL = {originalPattern: chrome.i18n.getMessage('forAll')}
 const NOMATCH_TEXT = chrome.i18n.getMessage('noMatch');
 const NONE_TEXT = chrome.i18n.getMessage('none');
 const NOMATCH_COLOR = '#D3D3D3';
+const WHITE = chrome.i18n.getMessage('white');
+const BLACK = chrome.i18n.getMessage('black');
 
 function findProxyMatch(url, activeSettings) {
   // note: we've already thrown out inactive settings and inactive patterns in background.js.
@@ -32,7 +34,10 @@ function findProxyMatch(url, activeSettings) {
         (item.protocols === schemeSet.all || item.protocols === schemeSet[scheme]) &&
           item.pattern.test(hostPort));
 
-      if (blackMatch) { continue; } // if blacklist matched, move to the next proxy
+      if (blackMatch) {
+        sendToLog(url, proxy, Utils.getProxyTitle(proxy), blackMatch, BLACK);
+        continue; // if blacklist matched, continue to the next proxy
+      }
 
       const whiteMatch = proxy.whitePatterns.find(item =>
         (item.protocols === schemeSet.all || item.protocols === schemeSet[scheme]) &&
@@ -43,7 +48,7 @@ function findProxyMatch(url, activeSettings) {
         const title = Utils.getProxyTitle(proxy);
         Utils.updateIcon('images/icon.svg', proxy.color, title, false, title, false);
         // TODO: use a Promise for sendToLogAndHandleToolbarIcon()
-        sendToLog(url, proxy, title, whiteMatch);
+        sendToLog(url, proxy, title, whiteMatch, WHITE);
         return prepareSetting(proxy);
   		}
     }
@@ -93,15 +98,16 @@ function prepareSetting(proxy) {
   return ret;
 }
 
-function sendToLog(url, proxy, title, matchedPattern) {
+function sendToLog(url, proxy, title, matchedPattern, whiteBlack) {
   // log only the data that is needed for display
   logger && logger.active && logger.add({
     url,
     title,
     color: proxy.color,
     address: proxy.address,
-    // Log should display whatever user typed, not our processed version.
+    // Log should display whatever user typed, not our processed version of the pattern
     matchedPattern: matchedPattern.originalPattern,
+    whiteBlack,
     timestamp: Date.now()
   });
 }

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -125,7 +125,7 @@ function selectMode() {
   // set color
   mode.style.color = mode.children[mode.selectedIndex].style.color;
 
-  console.log(this, "selectMode");
+  console.log(mode, "selectMode");
   // we already know the state of sync | this is set when manually changing the select
   // it is undefined when mode is switched from toolbar popup or on startup
   this && storageArea.set({mode: mode.value});

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -208,14 +208,8 @@ function processOptions(pref) {
   }
   
   pref.mode = pref.mode || 'disabled';                      // defaults to disabled
-  let foundPattern;
   prefKeys.forEach(id => {
     const item = pref[id];
-    
-    // check item.whitePatterns exists, otherwise this page won't render at all.
-    // some people import patterns json using the primary import button
-    // and therefore dont have items.whitePatterns.
-    if (item.whitePatterns && item.whitePatterns[0]) { foundPattern = true; }
 
     const div = temp.cloneNode(true);
     const node = [...div.children[0].children, ...div.children[1].children];
@@ -270,7 +264,7 @@ function processOptions(pref) {
   docfrag.hasChildNodes() && accounts.appendChild(docfrag);
   docfrag2.hasChildNodes() && mode.insertBefore(docfrag2, mode.lastElementChild);
 
-  if (FOXYPROXY_BASIC || !foundPattern) {  
+  if (FOXYPROXY_BASIC) {  
     mode.children[0].classList.add('hide');                 // hide by pattern option
     pref.mode === 'patterns' &&  (pref.mode = 'disabled');
   }

--- a/src/scripts/patterns.js
+++ b/src/scripts/patterns.js
@@ -117,8 +117,14 @@ function process() {
       break;
 
     case 'add':
-      proxy.blackPatterns.push(...blacklistSet);
-      processOptions();
+      if (typeof(this.dataset.black) !== 'undefined') {
+        proxy.blackPatterns.push(...blacklistSet);
+        processOptions();
+      }
+      else {
+        proxy.whitePatterns.push(PATTERN_ALL_WHITE);
+        processOptions();
+      }
       break;
   }
 }
@@ -194,7 +200,7 @@ function processEdit() {
 
     case 'delete|title':
       parent.style.opacity = 0;
-      setTimeout(() => { parent.remove(); }, 600);          // remove row
+      setTimeout(() => { parent.remove(); }, 300);          // remove row
       break;
   }
 }

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -30,14 +30,10 @@ function processOptions(pref) {
   prefKeys.sort((a, b) => pref[a].index - pref[b].index);   // sort by index
   
   pref.mode = pref.mode || 'disabled';                      // defaults to disabled
-  let foundPattern, hasProxySettings = false;
+  let hasProxySettings = false;
   prefKeys.forEach(id => {
 
     const item = pref[id];
-    // check item.whitePatterns exists, otherwise this page won't render at all.
-    // some people import patterns json using the primary import button
-    // and therefore dont have items.whitePatterns.
-    if (item.whitePatterns && item.whitePatterns[0]) { foundPattern = true; }
     
     if (!Utils.isUnsupportedType(item.type)) {              // if supported
 
@@ -55,7 +51,7 @@ function processOptions(pref) {
 
   docfrag.hasChildNodes() && temp.parentNode.insertBefore(docfrag, temp.nextElementSibling);
   
-  if (FOXYPROXY_BASIC || !foundPattern) {
+  if (FOXYPROXY_BASIC) {
     temp.parentNode.children[0].classList.add('hide');      // hide by pattern option
     pref.mode === 'patterns' && (pref.mode = 'disabled');
   } 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -540,14 +540,14 @@ input[type="text"] + button i.fa.fa-eye {
   visibility: hidden;
   width: 20em;
   background-color: #630;
-  color: #fff;
+  color: white;
   text-align: center;
-  border-radius: 10px;
-  padding: 0.3em;
+  border-radius: 3px;
+  padding: .8em;
   position: absolute;
   z-index: 1;
   bottom: 125%;
-  left: 50%;
+  left: 10%;
   margin-left: -2em;
   opacity: 0;
   transition: all 0.5s ease-in-out;
@@ -598,6 +598,30 @@ input[type="text"] + button i.fa.fa-eye {
 
 .tooltip i.fa:hover {
   color: #f90;
+}
+
+.tooltiptable {
+  /* https://stackoverflow.com/questions/20626685/better-way-to-set-distance-between-flexbox-items */
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  text-align: left;
+}
+
+.tooltiptable > div {
+  /*
+    1/ - 2 columns per row
+    .5em - spacing between rows 
+  */
+  box-sizing: border-box;
+  margin-bottom: .5em;
+  width: calc(1/2*100% - (1 - 1/2)*10px);
+}
+
+.tooltiptablefooter {
+  margin-top: 1em;
+  text-align: justify;
 }
 
 .monospace {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -579,6 +579,18 @@ input[type="text"] + button i.fa.fa-eye {
   left: 50%;
 }
 
+.tooltiptext.bottom {
+  top: 125%;
+  bottom: auto;
+}
+
+.tooltiptext.bottom::after {
+  bottom: 100%;
+  top: auto;
+  left: 75%;
+  border-color: transparent transparent #555 transparent;
+}
+
 .tooltip i.fa {
   font-size: 1.2em;
   color: black;


### PR DESCRIPTION
* Improved Logging — see URLs that matched blacklist patterns and URLs that didn't match anything are now in their own section.
* Patterns mode now exists even if there are no white patterns defined. This was the behavior of FoxyProxy before 7.x. Its absence when no white patterns are defined makes sense (no proxy will ever be used), but has been a source of tremendous confusion. Discussed at https://github.com/foxyproxy/firefox-extension/issues/49 but also many other places.
* When adding a new proxy, **Add whitelist pattern to match all URLs** is now on by default. Discussed at https://github.com/foxyproxy/firefox-extension/issues/49.
* On the patterns window, added new button for **Add whitelist pattern to match all URLs** similar to the existing button **Add black patterns to prevent this proxy being used for localhost & intranet/private IP addresses**.
* Patterns Cheat Sheet improvements — more examples and text explaining that blacklist patterns take precedence over whitelist patterns.
* Change an i18n key name so it works in chrome, too (chrome does not allow periods in key names).
* Remove unneeded console log messages.
* Faster deletion of patterns (faster animation)
