### PR TITLE
Regex bug fix

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -52,9 +52,6 @@ function checkPattern(pattern, type) {
   return regex;
 }
 
-
-
-
 function showResult(text, fail) {
 
   fail && result.classList.add('alert');

--- a/src/scripts/matcher.js
+++ b/src/scripts/matcher.js
@@ -25,23 +25,22 @@ function findProxyMatch(url, activeSettings) {
     // before using other parts of URL. For now, we ignore the other parts.
     const parsedUrl = new URL(url);
     const scheme = parsedUrl.protocol.substring(0, parsedUrl.protocol.length-1); // strip the colon
-    const hostPort = parsedUrl.host; // This includes port if one is specified
 
     for (const proxy of activeSettings.proxySettings) {
       
       // Check black patterns first
       const blackMatch = proxy.blackPatterns.find(item => 
         (item.protocols === schemeSet.all || item.protocols === schemeSet[scheme]) &&
-          item.pattern.test(hostPort));
+          item.pattern.test(Utils.getUrlStrByPatternType(item.type, parsedUrl)));
 
       if (blackMatch) {
         sendToMatchedLog(url, proxy, Utils.getProxyTitle(proxy), blackMatch, BLACK);
         continue; // if blacklist matched, continue to the next proxy
       }
 
-      const whiteMatch = proxy.whitePatterns.find(item =>
+      const whiteMatch = proxy.whitePatterns.find(item => 
         (item.protocols === schemeSet.all || item.protocols === schemeSet[scheme]) &&
-          item.pattern.test(hostPort));
+          item.pattern.test(Utils.getUrlStrByPatternType(item.type, parsedUrl)));;
       
       if (whiteMatch) {
   			// found a whitelist match, end here

--- a/src/scripts/pattern-tester.js
+++ b/src/scripts/pattern-tester.js
@@ -60,13 +60,15 @@ function testPattern() {
     return;
   }
 
-
+  
   // --- pattern check  
   const regex = checkPattern(pattern, type);
   if (!regex) { return; }
   
+  parsedURL = Utils.getUrlStrByPatternType(type.value, parsedURL);
+
   // --- pattern on URL check (pattern is valid)
-  regex.test(parsedURL.host) ? showResult(chrome.i18n.getMessage('patternMatch')) : 
+  regex.test(parsedURL) ? showResult(chrome.i18n.getMessage('patternMatch')) : 
                                 showResult(chrome.i18n.getMessage('patternNotMatch'), true);
 
 }

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -249,6 +249,11 @@ class Utils {
     }
   }
 
+  static getUrlStrByPatternType(type, parsedURL) {
+    return (type == PATTERN_TYPE_REGEXP)
+              ? parsedURL : parsedURL.host;
+  }
+  
 /*
   // utils only used for export, will be removed as DB format export is adapted
   static prepareForSettings(settings = {}) {


### PR DESCRIPTION
This is a bug fix PR. The regex patterns do not work when resolving browser URI requests, nor does it function when using the pattern tester.

The cause is due to no checking being performed on the type and all requests defaulting to PATTERN_TYPE_WILDCARD, and thus only checking the host of a given URI and not the full URI.

I have added code that will check whether the pattern type is either a wildcard or regex, and return the appropriate URI string.

I am currently using it in production on some nix machines on Firefox 97, and it is functioning as intended.